### PR TITLE
Cleaner hooking

### DIFF
--- a/Source/Main.c
+++ b/Source/Main.c
@@ -40,10 +40,10 @@ DWORD WINAPI LoopFunction(LPVOID lpParam)
 	VirtualProtect((void*)lengthLimit, 1, PAGE_EXECUTE_READWRITE, &_old_protect);
 	*lengthLimit = 1;
 
-	create_hook(client_base, 0x343e4, packet_hook);
-	create_hook(client_base, 0x32f00, rendering_hook_bi);
-	create_hook(client_base, 0x334aa, rendering_hook_ai);
-	create_hook(client_base, 0x3126d, hook_inputs);
+	create_hook(client_base, 0x343e4, packet_hook, 7);
+	create_hook(client_base, 0x32f00, rendering_hook_bi, 6);
+	create_hook(client_base, 0x334aa, rendering_hook_ai, 6);
+	create_hook(client_base, 0x3126d, hook_inputs, 6);
 
 	struct Menu* LoggerMenu = create_menu(300, 200, 0, "Logger");
 	LoggerMultitext = create_multitext(LoggerMenu, 0xffffff);

--- a/Source/Utils/Hook.c
+++ b/Source/Utils/Hook.c
@@ -1,12 +1,20 @@
 #include <Hook.h>
 
-void create_hook(int client_base, int address, void* func) {
-	DWORD old_protect;
+void create_hook(int client_base, int address, void* func, int length) {
+	if (length < 5) { return; }
 
-	unsigned char* hookLoc = (unsigned char*)(client_base+address);
-	VirtualProtect((void*)hookLoc, 6, PAGE_EXECUTE_READWRITE, &old_protect);
+	DWORD oldProtect;
 
-	*hookLoc = 0xE9;
-	*(DWORD*)(hookLoc + 1) = (DWORD)func - ((DWORD)hookLoc + 5);
-	*(hookLoc + 5) = 0x90;
+	unsigned char* hookLoc = (unsigned char*)(client_base + address);
+	VirtualProtect((LPVOID*)hookLoc, length, PAGE_EXECUTE_READWRITE, &oldProtect);
+
+	memset(hookLoc, 0x90, length);
+
+	DWORD relativeAddr = (DWORD)func - ((DWORD)hookLoc + 5);
+
+	*(BYTE*)hookLoc = 0xE9;
+	*(DWORD*)(hookLoc + 1) = relativeAddr;
+
+	DWORD temp;
+	VirtualProtect(hookLoc, length, oldProtect, &temp);
 }

--- a/Source/Utils/Hook.h
+++ b/Source/Utils/Hook.h
@@ -1,3 +1,3 @@
 #include <windows.h>
 
-void create_hook(int client_base, int address, void* func);
+void create_hook(int client_base, int address, void* func, int length);


### PR DESCRIPTION
In some cases, the length of the hook being 6 is not enough, because some opcodes might be left, potentially altering instructions in an unexpected way.